### PR TITLE
Update config.go fix the Ignore table format

### DIFF
--- a/canal/config.go
+++ b/canal/config.go
@@ -22,7 +22,7 @@ type DumpConfig struct {
 
 	Databases []string `toml:"dbs"`
 
-	// Ignore table format is db.table
+	// Ignore table format is db,table 
 	IgnoreTables []string `toml:"ignore_tables"`
 
 	// Dump only selected records. Quotes are mandatory


### PR DESCRIPTION
"Ignore table format is db.table " is not right, and fix the problem with ","
and please see canal/canal.go:162-166    "seps := strings.Split(ignoreTable, ",")"